### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: ./Ogma3/FrontendCode


### PR DESCRIPTION
Potential fix for [https://github.com/Genfic/Ogma/security/code-scanning/31](https://github.com/Genfic/Ogma/security/code-scanning/31)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default. The best minimal fix here is at the workflow root (applies to all jobs), setting:

- `contents: read`

This preserves current behavior (checkout/build) while preventing unintended write scopes if repository defaults are permissive or change later.

**File to edit:** `.github/workflows/node.js.yml`  
**Region:** after the `on:` trigger block and before `defaults:` (or equivalently before `jobs:`).  
No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
