### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,5 +1,7 @@
 name: Mirror
 on: [ push ]
+permissions:
+  contents: read
 jobs:
   mirror:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Genfic/Ogma/security/code-scanning/33](https://github.com/Genfic/Ogma/security/code-scanning/33)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained by least privilege.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for `actions/checkout` in typical usage and does not change the job’s intended mirroring behavior (which uses external credentials). This keeps functionality intact while satisfying CodeQL and documenting security intent.

Change needed in:
- `.github/workflows/mirror.yml` near the top-level keys (after `on:` is a clear location).

No imports, methods, or extra definitions are needed (YAML-only edit).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
